### PR TITLE
StyleSheet now proxies all the methods we needed from Glamor

### DIFF
--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -3,15 +3,27 @@
 /* Wraps glamor's stylesheet and exports a singleton for the rest
 *  of the app to use. */
 
-import { StyleSheet } from '../vendor/glamor/sheet'
+import { StyleSheet as GlamorStyle } from '../vendor/glamor/sheet'
 
-class StyleSheetExtended extends StyleSheet {
-  reset() {
-    return super.flush()
+class StyleSheet {
+  constructor() {
+    this.styleSheet = new GlamorStyle({ speedy: false, maxLength: 40 })
   }
-  getCSS({ min = true }) {
-    return super.rules().map(rule => rule.cssText).join(min ? '' : '\n')
+  get injected() {
+    return this.styleSheet.injected
+  }
+  inject() {
+    return this.styleSheet.inject()
+  }
+  insert(css) {
+    return this.styleSheet.insert(css)
+  }
+  reset() {
+    if (this.styleSheet.sheet) this.styleSheet.flush()
+  }
+  getCSS({ min = true } = {}) {
+    return this.styleSheet.rules().map(rule => rule.cssText).join(min ? '' : '\n')
   }
 }
 
-export default new StyleSheetExtended({ speedy: false, maxLength: 40 })
+export default new StyleSheet()

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -14,14 +14,14 @@ let index = 0
 const classNames = () => String.fromCodePoint(97 + index++)
 
 export const resetStyled = () => {
-  if (styleSheet.sheet) styleSheet.flush()
+  styleSheet.reset()
   index = 0
   return _styled(_styledComponent(_ComponentStyle(classNames)))
 }
 
 const stripWhitespace = str => str.trim().replace(/\s+/g, ' ')
 export const expectCSSMatches = (expectation, opts = { ignoreWhitespace: true }) => {
-  const css = styleSheet.rules().map(rule => rule.cssText).join('\n')
+  const css = styleSheet.getCSS({min: false})
   if (opts.ignoreWhitespace) {
     expect(stripWhitespace(css)).toEqual(stripWhitespace(expectation))
   } else {


### PR DESCRIPTION
Changed up the implementation of `StyleSheet` to depend on Glamor instead of inherit from it. This insulates us from public API changes in Glamor and should let us change our own logic a bit more easily in future.

Also, pointed the test utils at this new file since it does exactly what we need 👍 